### PR TITLE
Let JSON_ERROR_INVALID_PROPERTY_NAME be one case

### DIFF
--- a/src/KHerGe/JSON/JSON.php
+++ b/src/KHerGe/JSON/JSON.php
@@ -151,16 +151,14 @@ class JSON implements JSONInterface
 
                     break;
 
-                default:
-                    // php 7.0
-                    if (defined('JSON_ERROR_INVALID_PROPERTY_NAME')) {
-                        if (JSON_ERROR_INVALID_PROPERTY_NAME === json_last_error()) {
-                            throw new InvalidPropertyNameException(
-                                'The value contained a property with an invalid JSON key name.'
-                            );
-                        }
-                    }
+                case JSON_ERROR_INVALID_PROPERTY_NAME:
+                    throw new InvalidPropertyNameException(
+                        'The value contained a property with an invalid JSON key name.'
+                    );
 
+                    break;
+
+                default:
                     throw new UnknownException(
                         'An unrecognized encoding error was encountered: %s',
                         json_last_error_msg()


### PR DESCRIPTION
# Changed log
- The `JSON_ERROR_INVALID_PROPERTY_NAME` error JSON const is available on `php-7.0+` versions and this package requires `php-7.3` version at least since `3.0.0` version.
It's time to let `JSON_ERROR_INVALID_PROPERTY_NAME` const check move to one of case when using switch to check the `json_last_error()` function.